### PR TITLE
Replace expired domain theedg.es with edgenet.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,2 @@
-theedg.es
+edgenet.io
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-623476-20', 'theedg.es');
+        ga('create', 'UA-623476-20', 'edgenet.io');
         ga('send', 'pageview');
     </script>
 </head>

--- a/logo/integration.md
+++ b/logo/integration.md
@@ -47,7 +47,7 @@ Then add the following JavaScript right before the closing `</body>` tag.
 </script>
 ```
 
-This will then replace the static image with the animated logo. See this [demo page](http://theedg.es/logo/demo.html).
+This will then replace the static image with the animated logo. See this [demo page](http://edgenet.io/logo/demo.html).
 
 **Important:**
 By default, the plugin will create a canvas with exactly the same dimensions as the DOM element and try to scale the logo within these bounds. If you apply this to very small DOM elements (either in height or width), the logo might not show up at all.


### PR DESCRIPTION
I noticed the domain theedg.es was expired (now linking to some kind of business blog) and registered edgenet.io with a CNAME pointing to edgenet.github.io
